### PR TITLE
Updated GetBestColor to be more efficient using LockBits.

### DIFF
--- a/Tsukihi.csproj
+++ b/Tsukihi.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Discord.Net.Commands, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
GetPixel requires locking the Bitmap, which is inefficient for a large number of per-pixel operations. By switching to using LockBits, the entire clump of pixels can be loaded into memory and locked once, reducing the locking overhead. Also, the function no longer downloads a local copy of the image, but rather directly reads the stream from the WebRequest.